### PR TITLE
hooked the ID attribute back up on the cloned element

### DIFF
--- a/webroot/js/default.js
+++ b/webroot/js/default.js
@@ -112,7 +112,7 @@ $(document).ready(function(){
 		
 		$html = $('#filter-template').clone();
 		$html.removeClass('hidden');
-		$html.removeAttr('id');
+		$html.attr('id', 'filter-'+filterId);
 		$html.find('select,input').each(function(idx, elem){
 			$elem = $(elem);
 			$name = $elem.attr("name").replace('template',filterId);


### PR DESCRIPTION
symptom: previewed reports are empty, when filters exist. Saved reports are fine.

reason for the empty reports is that the "operator" in the filter was not being provided to the preview. So, every report was force-filtering with an "=" operator. 

The operator was not being sent to the form, because of a peculiar behaviour of cloning, and the "selected" property of an option element. Being "selected" means that the selected PROPERTY is defined, but it doesn't mean that the selected ATTRIBUTE exists. When we clone() the form to submit for a preview, we clone the attributes, but not the properties. Hence in the original form, the ">" operator might be selected, but in the cloned form (the one that gets submitted to render the preview), it's not selected.

So we need to do a little JavaScript trickery to ensure that the selected option has a "selected" ATTRIBUTE too. That's the bit that wasn't working. And the reason it wasn't working is because the ID of the select element wasn't being set after cloning the filter markup from its template.

Complicated little bug, that was. For such a diminutive solution.

[delivers #52388475]
