### PR TITLE
re-select the chosen option, after re-populating the select with new opt...

### DIFF
--- a/webroot/js/default.js
+++ b/webroot/js/default.js
@@ -177,8 +177,24 @@ $(document).ready(function(){
 				numChecked++;
 			}
 		}
+		
 		selects.each(function(idx, elem){
-			$(elem).children().remove().end().append($(options));
+			$elem = $(elem);
+			// get the selected option
+			var selectedoption = $elem.val();
+			// replace all the options with the new list
+			$elem.children().remove().end().append($(options));
+			// re-select it, if it exists!
+			$elem.val(selectedoption);
+			// force in the selected attribute, so that previews work
+			$elem.children().each(function(idx, opt){
+				$opt = $(opt);
+				if ($opt.attr('value') == selectedoption){
+					$opt.attr('selected','selected');
+				} else {
+					$opt.removeAttr('selected');
+				}
+			})
 		});
 		
 		// if there are no checkboxes checked, that changes some other things... you can't add a filter, and you 


### PR DESCRIPTION
...ions

A real headdesk mistake. There's this JavaScript that keeps the field lists synced with the checkboxes of fields that are visible. It wasn't retaining the selected option when it re-populated those select boxes.

This solves the problem and also does the extra bit to force the selected attribute to be present so it doesn't break preview functionality.

To test: 
- add filters. Edit the sorting. Save it. Then edit it again and see that now the fields are still selected.
- check and uncheck boxes on the "choose your content" panel, and see that your selected options are still OK.
- make sure preview still works too

[delivers #52484965]
