### PR TITLE
sanitize logical operator

### DIFF
--- a/Controller/AdHocReportsController.php
+++ b/Controller/AdHocReportsController.php
@@ -163,7 +163,8 @@ class AdHocReportsController extends AdHocReportingAppController {
 				}
 			}
 			if (count($conditionsList)>0) {
-				$logical = empty($this->data['AdHocReport']['FilterLogic'])?'OR':$this->data['AdHocReport']['FilterLogic'];
+				// Constrain the values to be either OR or AND
+				$logical = (isset($this->data['AdHocReport']['FilterLogic']) && $this->data['AdHocReport']['FilterLogic'] == "OR") ? "OR" : "AND";
 				// for eaxmple, $conditions will be like array("OR" => array("Users.name = 'ian'","Users.fieldname < 5") )
 				$conditions[$logical] = $conditionsList;
 			}


### PR DESCRIPTION
Experimentally, I found that if the operator in a Cake find() condition is not a valid logical operator (like "OMFG" instead of "OR"), Cake uses it as a column name in the WHERE clause. 
I expected that this would be a classic SQL injection hole. But it appears that Cake actually does some sanitation on the string... I couldn't break the SQL query using the typical injection tricks like "'; SHOW tables" or "' OR 1=1" etc.

So. While this isn't strictly a SQL injection vulnerability, it is an opportunity where someone fiddling with the form contents could produce a SQL error. To wit, putting "OMFG" into the form caused a "Column not found" error.

This PR simply constrains the value to "AND" or "OR".

Ternary operator does a nice job on this. If there were > 2 possibilities, I would have reached for a switch/case instead.

TO TEST

you need to put on your cracker hat and try to break the form by messing with the logical operator in the "filters" panel. Use Firebug and change the "OR" into something else. If you have debug mode on, you can see the resulting SQL query
