### PR TITLE
prevent submission of the form when adding a new filter

### DIFF
--- a/webroot/js/default.js
+++ b/webroot/js/default.js
@@ -141,6 +141,8 @@ $(document).ready(function(){
 		
 		
 		showhidefilterlogic();
+		
+		return false;
 	});
 	
 	$('#step-1-next').click(function(){


### PR DESCRIPTION
A <button> element acts like a submit button. So, we need to return false in its click event so the form doesn't submit.

This is an unreported bug with no pivotal ticket
