### PR TITLE
Fix XSS hole exposed through ad hoc report title

### DIFF
--- a/View/AdHocReports/report_display.ctp
+++ b/View/AdHocReports/report_display.ctp
@@ -10,7 +10,7 @@
 
     <img src="/img/tribehr_logo.png" alt="TribeHR" width="116" height="83" class="logo" /> 
     <div class="details">
-        <h1><?php echo ($reportName == '' ? 'Ad-Hoc Report' : $reportName);?></h1>
+        <h1><?php echo ($reportName == '' ? 'Ad-Hoc Report' : h($reportName));?></h1>
         <h2><?php echo h($settings['Config']['name']); ?></h2>
         <div class="timestamp">Report Generated : <strong><?php echo date('Y-m-d H:i:s'); ?></strong></div>
     </div>


### PR DESCRIPTION
Delivers [WEB-4593]

Fixes XSS hole in adhoc report title.

**Testing Notes**

This plugin is pulled in with Composer into the TribeHR project. So we need to pull in this updated code and ensure that when you create a new adhoc report an XSS hole cannot be exposed through the report title.
