### PR TITLE
Save filters as array instead of by field name to allow multiple filters per field

### DIFF
--- a/Controller/AdHocReportsController.php
+++ b/Controller/AdHocReportsController.php
@@ -156,9 +156,9 @@ class AdHocReportsController extends AdHocReportingAppController {
 						}
 					}
 					if ($criteria == ''){
-						$conditionsList[$filter['Field']] = $filter['Value'];
+						$conditionsList[] = array($filter['Field'] => $filter['Value']);
 					} else {
-						$conditionsList[$filter['Field']." ".$criteria] = $filter['Value'];
+						$conditionsList[] = array($filter['Field']." ".$criteria => $filter['Value']);
 					}
 				}
 			}


### PR DESCRIPTION
NOTE: you will need to ensure composer pulls down the latest version of this package

This fix allows multiple filters to be added for the same field name. This can be useful when allowing ANY of the filters to match.

**Testing Notes**

Create an adhoc report with multiple filters on the same field and allow ANY filter to match. This was required by sales when checking against multiple custom fields.
