### PR TITLE
Replace deprecated live() with on()

### DIFF
--- a/webroot/js/default.js
+++ b/webroot/js/default.js
@@ -299,7 +299,7 @@ $(document).ready(function() {
     
     // change tr background color when checked
     // closest parent element
-    $("tr :checkbox[name*='[Add]']").live("click", function() {
+    $("tr :checkbox[name*='[Add]']").on("click", function() {
         $(this).closest("tr").css("background-color", this.checked ? "#eee" : "");
     });
     


### PR DESCRIPTION
As of jquery 1.7 (this plugin uses 1.7.1 at the time of this commit) the use of .live()
to dynamically bind has been deprecated. We are now using on().

This is a smaller PR to support my work on WEB-5018
