### PR TITLE
allow zero in filter value [WEB-5096]

### DIFF
--- a/Controller/AdHocReportsController.php
+++ b/Controller/AdHocReportsController.php
@@ -115,7 +115,7 @@ class AdHocReportsController extends AdHocReportingAppController {
 			if (!empty($this->request->data['Filters'])){
 				foreach($this->request->data['Filters'] as $filter){
 					
-					if (empty($filter['Value'])){
+					if (empty($filter['Value']) && !is_numeric($filter['Value'])) {
 						continue;
 					}
 					


### PR DESCRIPTION
This was a little nugget of low-hanging fruit for a late afternoon at the slack-end of an iteration.
Ad Hoc report filters didn't allow a zero, because it was using empty() to detect blankness.

It's explained pretty well in the Jira ticket.
https://tribehr.atlassian.net/browse/WEB-5096
# Testing notes

This affects all ad hoc filters on all models... but they all use the same filter magic so it doesn't mean you need to test a report on every single model.
On the page where you add filters, that "Value" field will accept any input. Leaving it empty means the filter does nothing.
The consequence of this PR is that entering a 0 in that box will actually match a zero, it won't be treated as an "empty".
